### PR TITLE
Reduce rand dependency to rand_core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ edition = "2018"
 
 [dev-dependencies]
 blake2 = "0.8.1"
+rand = { version = "0.7" }
 
 [dependencies]
 algebra = { git = "https://github.com/scipr-lab/zexe/", features = [ "parallel" ] }
@@ -29,7 +30,7 @@ r1cs-core = { git = "https://github.com/scipr-lab/zexe/" }
 
 poly-commit = { git = "https://github.com/scipr-lab/poly-commit" }
 
-rand = { version = "0.7" }
+rand_core = { version = "0.5" }
 rand_chacha = { version = "0.2.1" }
 rayon = { version = "1" }
 digest = { version = "0.8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ edition = "2018"
 
 [dev-dependencies]
 blake2 = "0.8.1"
-rand = { version = "0.7" }
 
 [dependencies]
 algebra = { git = "https://github.com/scipr-lab/zexe/", features = [ "parallel" ] }

--- a/src/ahp/mod.rs
+++ b/src/ahp/mod.rs
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn domain_unnormalized_bivariate_lagrange_poly_diff_inputs() {
-        let rng = &mut rand::thread_rng();
+        let rng = &mut rand_core::OsRng;
         for domain_size in 1..10 {
             let domain = EvaluationDomain::<Fr>::new(1 << domain_size).unwrap();
             let x = Fr::rand(rng);

--- a/src/ahp/prover.rs
+++ b/src/ahp/prover.rs
@@ -9,7 +9,7 @@ use algebra::{Field, PrimeField};
 use ff_fft::{EvaluationDomain, Evaluations as EvaluationsOnDomain};
 use poly_commit::{LabeledPolynomial, Polynomial};
 use r1cs_core::{ConstraintSynthesizer, SynthesisError};
-use rand::Rng;
+use rand_core::RngCore;
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::marker::PhantomData;
@@ -268,7 +268,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
     }
 
     /// Output the first round message and the next state.
-    pub fn prover_first_round<'a, 'b, R: Rng, C: ConstraintSynthesizer<F>>(
+    pub fn prover_first_round<'a, 'b, R: RngCore, C: ConstraintSynthesizer<F>>(
         s: ProverState<'a, 'b, F, C>,
         rng: &mut R,
     ) -> Result<(ProverMsg<F>, ProverFirstOracles<'b, F>, ProverState<'a, 'b, F, C>), Error> {
@@ -393,7 +393,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
     }
 
     /// Output the second round message and the next state.
-    pub fn prover_second_round<'a, 'b, R: Rng, C: ConstraintSynthesizer<F>>(
+    pub fn prover_second_round<'a, 'b, R: RngCore, C: ConstraintSynthesizer<F>>(
         ver_message: &VerifierFirstMsg<F>,
         prover_state: ProverState<'a, 'b, F, C>,
         _r: &mut R,
@@ -608,7 +608,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
     }
 
     /// Output the third round message and the next state.
-    pub fn prover_third_round<'a, 'b, R: Rng, C: ConstraintSynthesizer<F>>(
+    pub fn prover_third_round<'a, 'b, R: RngCore, C: ConstraintSynthesizer<F>>(
         ver_message: &VerifierSecondMsg<F>,
         prover_state: ProverState<'a, 'b, F, C>,
         _r: &mut R,
@@ -745,7 +745,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
     }
 
     /// Output the fourth round message and the next state.
-    pub fn prover_fourth_round<'a, 'b, R: Rng, C: ConstraintSynthesizer<F>>(
+    pub fn prover_fourth_round<'a, 'b, R: RngCore, C: ConstraintSynthesizer<F>>(
         ver_message: &VerifierThirdMsg<F>,
         prover_state: ProverState<'a, 'b, F, C>,
         _r: &mut R,

--- a/src/ahp/verifier.rs
+++ b/src/ahp/verifier.rs
@@ -5,7 +5,7 @@ use crate::ahp::indexer::IndexInfo;
 use crate::ahp::prover::*;
 use crate::ahp::*;
 use r1cs_core::ConstraintSynthesizer;
-use rand::Rng;
+use rand_core::RngCore;
 
 use algebra::PrimeField;
 use ff_fft::EvaluationDomain;
@@ -53,7 +53,7 @@ pub struct VerifierThirdMsg<F> {
 
 impl<F: PrimeField> AHPForR1CS<F> {
     /// Output the first message and next round state.
-    pub fn verifier_first_round<R: Rng, C: ConstraintSynthesizer<F>>(
+    pub fn verifier_first_round<R: RngCore, C: ConstraintSynthesizer<F>>(
         index_info: IndexInfo<F, C>,
         rng: &mut R,
     ) -> Result<(VerifierFirstMsg<F>, VerifierState<F, C>), Error> {
@@ -93,7 +93,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
     }
 
     /// Output the second message and next round state.
-    pub fn verifier_second_round<R: Rng, C: ConstraintSynthesizer<F>>(
+    pub fn verifier_second_round<R: RngCore, C: ConstraintSynthesizer<F>>(
         state: VerifierState<F, C>,
         rng: &mut R,
     ) -> (VerifierSecondMsg<F>, VerifierState<F, C>) {
@@ -123,7 +123,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
     }
 
     /// Output the third message and next round state.
-    pub fn verifier_third_round<R: Rng, C: ConstraintSynthesizer<F>>(
+    pub fn verifier_third_round<R: RngCore, C: ConstraintSynthesizer<F>>(
         state: VerifierState<F, C>,
         rng: &mut R,
     ) -> (VerifierThirdMsg<F>, VerifierState<F, C>) {
@@ -154,7 +154,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
     }
 
     /// Output the fourth message and next round state.
-    pub fn verifier_fourth_round<R: Rng, C: ConstraintSynthesizer<F>>(
+    pub fn verifier_fourth_round<R: RngCore, C: ConstraintSynthesizer<F>>(
         state: VerifierState<F, C>,
         rng: &mut R,
     ) -> VerifierState<F, C> {
@@ -184,7 +184,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
     }
 
     /// Output the query state and next round state.
-    pub fn verifier_query_set<'a, 'b, R: Rng, C: ConstraintSynthesizer<F>>(
+    pub fn verifier_query_set<'a, 'b, R: RngCore, C: ConstraintSynthesizer<F>>(
         state: VerifierState<F, C>,
         _: &'a mut R,
     ) -> (QuerySet<'b, F>, VerifierState<F, C>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ use digest::Digest;
 use poly_commit::multi_pc::Evaluations;
 use poly_commit::{LabeledCommitment, MultiPolynomialCommitment as MultiPC, PCCommitterKey};
 use r1cs_core::ConstraintSynthesizer;
-use rand::Rng;
+use rand_core::RngCore;
 use std::marker::PhantomData;
 
 /// Implements a Fiat-Shamir based Rng that allows one to incrementally update
@@ -60,7 +60,7 @@ impl<F: PrimeField, PC: MultiPC<F>, D: Digest> Marlin<F, PC, D> {
 
     /// Generate the universal prover and verifier keys for the
     /// argument system.
-    pub fn universal_setup<R: Rng>(
+    pub fn universal_setup<R: RngCore>(
         num_constraints: usize,
         num_variables: usize,
         num_non_zero: usize,
@@ -113,7 +113,7 @@ impl<F: PrimeField, PC: MultiPC<F>, D: Digest> Marlin<F, PC, D> {
     }
 
     /// Create a zkSNARK assserting that the constraint system is satisfied.
-    pub fn prove<C: ConstraintSynthesizer<F>, R: Rng>(
+    pub fn prove<C: ConstraintSynthesizer<F>, R: RngCore>(
         universal_pk: &UniversalProverKey<F, PC>,
         index_pk: &IndexProverKey<F, PC, C>,
         c: C,
@@ -256,7 +256,7 @@ impl<F: PrimeField, PC: MultiPC<F>, D: Digest> Marlin<F, PC, D> {
 
     /// Verify that a proof for the constrain system defined by `C` asserts that
     /// all constraints are satisfied.
-    pub fn verify<C: ConstraintSynthesizer<F>, R: Rng>(
+    pub fn verify<C: ConstraintSynthesizer<F>, R: RngCore>(
         universal_vk: &UniversalVerifierKey<F, PC>,
         index_vk: &IndexVerifierKey<F, PC, C>,
         public_input: &[F],

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,7 +1,7 @@
 use algebra::{FromBytes, ToBytes};
 use digest::Digest;
 use generic_array::GenericArray;
-use rand::{RngCore, SeedableRng};
+use rand_core::{RngCore, SeedableRng};
 use rand_chacha::ChaChaRng;
 use std::marker::PhantomData;
 
@@ -32,7 +32,7 @@ impl<D: Digest> RngCore for FiatShamirRng<D> {
     }
 
     #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
         Ok(self.r.fill_bytes(dest))
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -43,7 +43,6 @@ mod marlin {
     use algebra::{curves::bls12_377::Bls12_377, fields::bls12_377::Fr};
     use blake2::Blake2s;
     use poly_commit::{multi_pc::mpc_from_spc::*, single_pc::kzg10::KZG10};
-    use rand::thread_rng;
     use std::ops::MulAssign;
 
     type MultiPC = MultiPCFromSinglePC<Fr, KZG10<Bls12_377>>;
@@ -51,7 +50,7 @@ mod marlin {
     type MarlinInst = Marlin<Fr, MultiPC, Blake2s>;
 
     fn test_circuit(num_constraints: usize, num_variables: usize) {
-        let rng = &mut thread_rng();
+        let rng = &mut rand_core::OsRng;
 
         let (universal_pk, universal_vk) = MarlinInst::universal_setup(100, 25, 100, rng).unwrap();
 


### PR DESCRIPTION
Accompanies https://github.com/scipr-lab/poly-commit/pull/2 so it'll build and past tests with the extra line
```
poly-commit = { git = "https://github.com/burdges/poly-commit" }
```

I added an extra commit to remove rand from the dev-dependencies, but that improves nothing really, so maybe omit that one, as you like.