### PR TITLE
Empty prover message

### DIFF
--- a/src/ahp/prover.rs
+++ b/src/ahp/prover.rs
@@ -72,7 +72,7 @@ impl<F: Field> algebra_core::ToBytes for ProverMsg<F> {
     fn write<W: algebra_core::io::Write>(&self, w: W) -> algebra_core::io::Result<()> {
         match self {
             ProverMsg::EmptyMessage => Ok(()),
-            ProverMsg::FieldElements(field_elems) => field_elems.write(w)
+            ProverMsg::FieldElements(field_elems) => field_elems.write(w),
         }
     }
 }

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -163,7 +163,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>, C: ConstraintSynthesizer<F>> Pr
             .iter()
             .map(|v| match v {
                 ProverMsg::EmptyMessage => 0,
-                ProverMsg::FieldElements(elems) => elems.len()
+                ProverMsg::FieldElements(elems) => elems.len(),
             })
             .sum();
         let prover_msg_size_in_bytes = num_prover_messages * size_of_fe_in_bytes;

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -161,7 +161,10 @@ impl<F: PrimeField, PC: PolynomialCommitment<F>, C: ConstraintSynthesizer<F>> Pr
         let num_prover_messages: usize = self
             .prover_messages
             .iter()
-            .map(|v| v.field_elements.len())
+            .map(|v| match v {
+                ProverMsg::EmptyMessage => 0,
+                ProverMsg::FieldElements(elems) => elems.len()
+            })
             .sum();
         let prover_msg_size_in_bytes = num_prover_messages * size_of_fe_in_bytes;
         let arg_size = size_bytes_comms_with_degree_bounds


### PR DESCRIPTION
Add a clear option for the prover's (non-oracle) message to be empty. Since _all_ prover messages are now empty in the newest optimized version of Marlin, it's less confusing if that's very explicit